### PR TITLE
3033 Перевизначення помикли яка виникає під час одночасного забирання задачі двома відповідальними

### DIFF
--- a/modules/web/src/com/haulmont/cuba/web/messages.properties
+++ b/modules/web/src/com/haulmont/cuba/web/messages.properties
@@ -294,7 +294,7 @@ hotDeployClassCastException.caption=Помилка приведення клас
 hotDeployClassCastException.message=Після hot deployment завантажувач класів містить два екземпляри класу "%s". \
   Знову відчиніть всі екрани, які використовують цей клас.
 
-info.EntitySave=%s %s збережений успішно
+info.EntitySave=%s %s збережена успішно
 
 # Supported data types
 Datatype.decimal=Decimal

--- a/modules/web/src/com/haulmont/cuba/web/messages_uk.properties
+++ b/modules/web/src/com/haulmont/cuba/web/messages_uk.properties
@@ -294,7 +294,7 @@ hotDeployClassCastException.caption=Помилка приведення клас
 hotDeployClassCastException.message=Після hot deployment завантажувач класів містить два екземпляри класу "%s". \
   Знову відчиніть всі екрани, які використовують цей клас.
 
-info.EntitySave=%s %s збережений успішно
+info.EntitySave=%s %s збережена успішно
 
 # Supported data types
 Datatype.decimal=Decimal

--- a/modules/web/src/com/itk/kdp/web/ActivitiTaskAlreadyClaimedExceptionHandler.java
+++ b/modules/web/src/com/itk/kdp/web/ActivitiTaskAlreadyClaimedExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.itk.kdp.web;
+
+import com.haulmont.cuba.core.global.Messages;
+import com.haulmont.cuba.gui.Notifications;
+import com.haulmont.cuba.gui.exception.AbstractUiExceptionHandler;
+import org.springframework.stereotype.Component;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+@Component(ActivitiTaskAlreadyClaimedExceptionHandler.NAME)
+public class ActivitiTaskAlreadyClaimedExceptionHandler extends AbstractUiExceptionHandler {
+    public static final String NAME = "kdp_ActivitiTaskAlreadyClaimedExceptionHandler";
+    @Inject
+    private Messages messages;
+
+    public ActivitiTaskAlreadyClaimedExceptionHandler() {
+        super("org.activiti.engine.ActivitiTaskAlreadyClaimedException");
+    }
+    @Override
+    protected void doHandle(String className, String message, @Nullable Throwable throwable, UiContext context) {
+
+        if (throwable != null) {
+        context.getDialogs().createExceptionDialog()
+                .withThrowable(throwable)
+                .withCaption(messages.getMainMessage("ActivitiTaskAlreadyClaimedException.ErrorCaption"))
+                .withMessage(messages.getMainMessage("ActivitiTaskAlreadyClaimedException.ErrorMessage"))
+                .show();
+        } else {
+            context.getNotifications().create(Notifications.NotificationType.ERROR)
+                    .withCaption(messages.getMainMessage("ActivitiTaskAlreadyClaimedException.ErrorCaption"))
+                    .withDescription(messages.getMainMessage("ActivitiTaskAlreadyClaimedException.ErrorMessage"))
+                    .show();
+        }
+    }
+}

--- a/modules/web/src/com/itk/kdp/web/messages.properties
+++ b/modules/web/src/com/itk/kdp/web/messages.properties
@@ -60,3 +60,5 @@ share.text = Доброго дня, <br /><br />\
 menu_config.kdp_VacationBalance.browse=Залишки відпусток
 menu_config.kdp_UsersFpmnt.browse=Користувачі "Фабрика платежів"
 menu_config.kdp_OperatorAccessRequest.browse=Заявка на доступ операторів КБ
+ActivitiTaskAlreadyClaimedException.ErrorCaption = Помилка:
+ActivitiTaskAlreadyClaimedException.ErrorMessage=Задача вже взята в роботу іншим користувачем

--- a/modules/web/src/com/itk/kdp/web/messages_ru.properties
+++ b/modules/web/src/com/itk/kdp/web/messages_ru.properties
@@ -34,3 +34,5 @@ share.subject = %s прокоментировал %s %s.
 share.text = Добрый день, <br /><br />\
   обратите внимание %s %s. <br /><br />\
   %s
+ActivitiTaskAlreadyClaimedException.ErrorCaption = Ошибка:
+ActivitiTaskAlreadyClaimedException.ErrorMessage=Задача уже взята в работу другим пользователем

--- a/modules/web/src/com/itk/kdp/web/messages_uk.properties
+++ b/modules/web/src/com/itk/kdp/web/messages_uk.properties
@@ -59,5 +59,5 @@ share.subject = %s прокоментував %s %s.
 share.text = Доброго дня, <br /><br />\
   зверніть увагу %s %s. <br /><br />\
   %s
-
-
+ActivitiTaskAlreadyClaimedException.ErrorCaption = Помилка:
+ActivitiTaskAlreadyClaimedException.ErrorMessage=Задача вже взята в роботу іншим користувачем


### PR DESCRIPTION
Сворено бін "ActivitiTaskAlreadyClaimedExceptionHandler" який перехоплює повідомлення та виводить його в потрібному вигляді.